### PR TITLE
Qt6 : "QtWidgets.QAction" -> "QtGui.QAction"

### DIFF
--- a/patches/0001-Initial-implementation-of-a-tool-system.patch
+++ b/patches/0001-Initial-implementation-of-a-tool-system.patch
@@ -1,20 +1,20 @@
-From d63b9271453f4f5a6d22bec9cc422ddbcbf6828e Mon Sep 17 00:00:00 2001
-From: Bernhard Ehlers <none@b-ehlers.de>
-Date: Thu, 28 Dec 2017 15:17:11 +0100
-Subject: [PATCH 1/8] Initial implementation of a tool system
+From de8f8289c04eb613251faeba5b49b93b2165da24 Mon Sep 17 00:00:00 2001
+From: Raizo62 <silicium62-github@yahoo.fr>
+Date: Sun, 8 Feb 2026 13:20:55 +0100
+Subject: [PATCH] Initial implementation of a tool system
 
 ---
- gns3/graphics_view.py | 20 +++++++++++
- gns3/main_window.py   | 21 ++++++++++++
- gns3/tool.py          | 93 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ gns3/graphics_view.py | 20 ++++++++++
+ gns3/main_window.py   | 21 ++++++++++
+ gns3/tool.py          | 93 +++++++++++++++++++++++++++++++++++++++++++
  3 files changed, 134 insertions(+)
  create mode 100644 gns3/tool.py
 
 diff --git a/gns3/graphics_view.py b/gns3/graphics_view.py
-index d965a177..9d589949 100644
+index 5f22abdb..90d1ae28 100644
 --- a/gns3/graphics_view.py
 +++ b/gns3/graphics_view.py
-@@ -819,6 +819,17 @@ class GraphicsView(QtWidgets.QGraphicsView):
+@@ -866,6 +866,17 @@ class GraphicsView(QtWidgets.QGraphicsView):
              show_in_file_manager_action.triggered.connect(self.showInFileManagerSlot)
              menu.addAction(show_in_file_manager_action)
  
@@ -24,15 +24,15 @@ index d965a177..9d589949 100644
 +            tool_menu_action.setIcon(QtGui.QIcon(':/icons/applications.svg'))
 +            menu.addAction(tool_menu_action.menuAction())
 +            for tool in tool_list:
-+                tool_action = QtWidgets.QAction(tool.name(), tool_menu_action)
++                tool_action = QtGui.QAction(tool.name(), tool_menu_action)
 +                tool_action.setData(tool)
 +                tool_action.triggered.connect(self.startToolSlot)
 +                tool_menu_action.addAction(tool_action)
 +
          if not sys.platform.startswith("darwin") and True in list(map(lambda item: isinstance(item, NodeItem) and hasattr(item.node(), "bringToFront"), items)):
              # Action: bring console or window to front (Windows and Linux only)
-             bring_to_front_action = QtWidgets.QAction("Bring to front", menu)
-@@ -1625,3 +1636,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
+             bring_to_front_action = QtGui.QAction("Bring to front", menu)
+@@ -1724,3 +1735,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
              self._main_window.uiDeviceMenu.setEnabled(True)
          else:
              self._main_window.uiDeviceMenu.setEnabled(False)
@@ -46,10 +46,10 @@ index d965a177..9d589949 100644
 +        if action and action.data():
 +            action.data().run(self._topology.project(), self.scene().selectedItems())
 diff --git a/gns3/main_window.py b/gns3/main_window.py
-index 0f87bcc2..46cecf59 100644
+index a257a145..d5f0cc11 100644
 --- a/gns3/main_window.py
 +++ b/gns3/main_window.py
-@@ -57,6 +57,7 @@ from .status_bar import StatusBarHandler
+@@ -56,6 +56,7 @@ from .status_bar import StatusBarHandler
  from .registry.appliance import ApplianceError
  from .template_manager import TemplateManager
  from .appliance_manager import ApplianceManager
@@ -57,7 +57,7 @@ index 0f87bcc2..46cecf59 100644
  
  log = logging.getLogger(__name__)
  
-@@ -109,6 +110,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
+@@ -126,6 +127,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
          self._project_dialog = None
          self.recent_file_actions = []
          self.recent_project_actions = []
@@ -65,7 +65,7 @@ index 0f87bcc2..46cecf59 100644
          self._start_time = time.time()
          local_config = LocalConfig.instance()
          #local_config.config_changed_signal.connect(self._localConfigChangedSlot)
-@@ -166,6 +168,16 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
+@@ -183,6 +185,16 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
          self.recent_project_actions_separator.setVisible(False)
          self.uiFileMenu.addActions(self.recent_project_actions)
  
@@ -74,7 +74,7 @@ index 0f87bcc2..46cecf59 100644
 +        if tool_list:
 +            self.uiToolsMenu.addSeparator()
 +            for tool in tool_list:
-+                action = QtWidgets.QAction(tool.name(), self.uiToolsMenu)
++                action = QtGui.QAction(tool.name(), self.uiToolsMenu)
 +                action.setData(tool)
 +                action.triggered.connect(self.startToolSlot)
 +                self.uiToolsMenu.addAction(action)
@@ -82,7 +82,7 @@ index 0f87bcc2..46cecf59 100644
          # set the window icon
          self.setWindowIcon(QtGui.QIcon(":/images/gns3.ico"))
  
-@@ -472,6 +484,15 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
+@@ -488,6 +500,15 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                  (project_id, ) = action.data()
                  Topology.instance().createLoadProject({"project_id": project_id})
  
@@ -198,5 +198,5 @@ index 00000000..088867c2
 +        """ return menu tool list """
 +        return self._tools
 -- 
-2.15.1 (Apple Git-101)
+2.47.3
 


### PR DESCRIPTION
Hi

In the file "patches/0001-Initial-implementation-of-a-tool-system.patch" : "QtWidgets.QAction" (from QT5) becomes "QtGui.QAction" (from QT6)
